### PR TITLE
Update janus-ar.gemspec to fix `replca` typo on gem description

### DIFF
--- a/janus-ar.gemspec
+++ b/janus-ar.gemspec
@@ -5,8 +5,8 @@ require File.expand_path('lib/janus/version.rb', __dir__)
 Gem::Specification.new do |gem|
   gem.authors       = ['Lloyd Watkin']
   gem.email         = ['lloyd@olioex.com']
-  gem.description   = 'Read/Write proxy for ActiveRecord using primary/replca databases'
-  gem.summary       = 'Read/Write proxy for ActiveRecord using primary/replca databases'
+  gem.description   = 'Read/Write proxy for ActiveRecord using primary/replica databases'
+  gem.summary       = 'Read/Write proxy for ActiveRecord using primary/replica databases'
   gem.homepage      = 'https://github.com/olioex/janus-ar'
   gem.licenses      = ['MIT']
   gem.metadata      = {


### PR DESCRIPTION
Fix gem description typo `replca` to `replica`