### PR TITLE
Release primary stickiness automatically per request/job

### DIFF
--- a/lib/janus-ar.rb
+++ b/lib/janus-ar.rb
@@ -20,3 +20,5 @@ ActiveSupport.on_load(:active_record) do
     subscriber.extend Janus::Logging::Subscriber
   end
 end
+
+require 'janus-ar/railtie' if defined?(Rails::Railtie)

--- a/lib/janus-ar/context.rb
+++ b/lib/janus-ar/context.rb
@@ -1,15 +1,24 @@
 # frozen_string_literal: true
 
-module Janus
-  class Context
-    THREAD_KEY = :janus_ar_context
+require 'active_support/isolated_execution_state'
 
-    # Stores the staged data with an expiration time based on the current time,
-    # and clears any expired entries. Returns true if any changes were made to
-    # the current store
-    def initialize(primary: false, expiry: nil)
+module Janus
+  # Per-execution state that records whether the current unit of work has been
+  # pinned to the primary (e.g. after a write, so subsequent reads stay
+  # consistent). State is stored in ActiveSupport::IsolatedExecutionState so it
+  # follows the application's configured isolation level (thread or fiber),
+  # matching ActiveRecord itself.
+  #
+  # Because pooled threads/fibers are reused across requests and jobs, the
+  # context MUST be released between units of work or a thread that performed a
+  # single write would keep routing every later read to the primary. The Rails
+  # integration (see Janus::Railtie) does this automatically; outside Rails,
+  # call Janus::Context.release_all yourself (e.g. in a Sidekiq middleware).
+  class Context
+    STATE_KEY = :janus_ar_context
+
+    def initialize(primary: false)
       @primary = primary
-      @expiry = expiry
       @last_used_connection = :primary
     end
 
@@ -17,13 +26,8 @@ module Janus
       @primary = true
     end
 
-    def potential_write
-      stick_to_primary
-    end
-
     def release_all
       @primary = false
-      @expiry = nil
       @last_used_connection = nil
     end
 
@@ -58,22 +62,17 @@ module Janus
         current.last_used_connection
       end
 
+      # Release the context at the start of every unit of work wrapped by the
+      # given ActiveSupport executor (web requests, ActiveJob and
+      # Sidekiq-on-Rails jobs all run inside it).
+      def install_reset_hook(executor)
+        executor.to_run { Janus::Context.release_all }
+      end
+
       protected
 
       def current
-        fetch(THREAD_KEY) { new }
-      end
-
-      def fetch(key)
-        get(key) || set(key, yield)
-      end
-
-      def get(key)
-        Thread.current.thread_variable_get(key)
-      end
-
-      def set(key, value)
-        Thread.current.thread_variable_set(key, value)
+        ActiveSupport::IsolatedExecutionState[STATE_KEY] ||= new
       end
     end
   end

--- a/lib/janus-ar/railtie.rb
+++ b/lib/janus-ar/railtie.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails/railtie'
+
+module Janus
+  class Railtie < ::Rails::Railtie
+    # Clear Janus' per-request primary stickiness at the start of every unit of
+    # work wrapped by the Rails executor (web requests, ActiveJob and
+    # Sidekiq-on-Rails jobs). Without this, a pooled thread that performs a
+    # write keeps routing reads to the primary for the rest of its life.
+    initializer 'janus.clear_context_per_execution' do |app|
+      Janus::Context.install_reset_hook(app.executor)
+    end
+  end
+end

--- a/spec/lib/janus-ar/context_spec.rb
+++ b/spec/lib/janus-ar/context_spec.rb
@@ -58,6 +58,23 @@ RSpec.describe Janus::Context do
       expect(other).to be false
       expect(described_class.use_primary?).to be true
     end
+
+    it 'isolates the last used connection between threads' do
+      described_class.used_connection(:replica)
+      other = Thread.new do
+        described_class.used_connection(:primary)
+        described_class.last_used_connection
+      end.value
+      expect(other).to eq(:primary)
+      expect(described_class.last_used_connection).to eq(:replica)
+    end
+
+    it 'is safe to release a context that was never touched' do
+      Thread.new do
+        expect { described_class.release_all }.not_to raise_error
+        expect(described_class.use_primary?).to be false
+      end.join
+    end
   end
 
   describe '.install_reset_hook' do
@@ -77,6 +94,21 @@ RSpec.describe Janus::Context do
       described_class.install_reset_hook(executor)
 
       executor.wrap { described_class.stick_to_primary }
+
+      leaked = nil
+      executor.wrap { leaked = described_class.use_primary? }
+      expect(leaked).to be false
+    end
+
+    it 'still starts the next run clean after the previous run raised' do
+      described_class.install_reset_hook(executor)
+
+      expect do
+        executor.wrap do
+          described_class.stick_to_primary
+          raise 'boom'
+        end
+      end.to raise_error('boom')
 
       leaked = nil
       executor.wrap { leaked = described_class.use_primary? }

--- a/spec/lib/janus-ar/context_spec.rb
+++ b/spec/lib/janus-ar/context_spec.rb
@@ -1,13 +1,20 @@
 # frozen_string_literal: true
 
 require 'janus-ar/context'
+require 'active_support/executor'
 
 RSpec.describe Janus::Context do
+  after(:each) { described_class.release_all }
+
   describe '#initialize' do
-    it 'sets the primary flag and expiry' do
-      context = described_class.new(primary: true, expiry: 60)
-      expect(context.use_primary?).to be true
+    it 'defaults to the replica and a primary last-used connection' do
+      context = described_class.new
+      expect(context.use_primary?).to be false
       expect(context.last_used_connection).to eq(:primary)
+    end
+
+    it 'can be created pinned to the primary' do
+      expect(described_class.new(primary: true).use_primary?).to be true
     end
   end
 
@@ -19,17 +26,10 @@ RSpec.describe Janus::Context do
     end
   end
 
-  describe '#potential_write' do
-    it 'calls stick_to_primary' do
-      context = described_class.new
-      expect(context).to receive(:stick_to_primary)
-      context.potential_write
-    end
-  end
-
   describe '#release_all' do
-    it 'resets the primary flag and expiry' do
-      context = described_class.new(primary: true, expiry: 60)
+    it 'resets the primary flag and the last used connection' do
+      context = described_class.new(primary: true)
+      context.used_connection(:primary)
       context.release_all
       expect(context.use_primary?).to be false
       expect(context.last_used_connection).to be_nil
@@ -39,8 +39,48 @@ RSpec.describe Janus::Context do
   describe '#used_connection' do
     it 'sets the last used connection' do
       context = described_class.new
-      context.used_connection(:secondary)
-      expect(context.last_used_connection).to eq(:secondary)
+      context.used_connection(:replica)
+      expect(context.last_used_connection).to eq(:replica)
+    end
+  end
+
+  describe 'class-level access' do
+    it 'sticks and releases the current execution state' do
+      described_class.stick_to_primary
+      expect(described_class.use_primary?).to be true
+      described_class.release_all
+      expect(described_class.use_primary?).to be false
+    end
+
+    it 'isolates state between threads' do
+      described_class.stick_to_primary
+      other = Thread.new { described_class.use_primary? }.value
+      expect(other).to be false
+      expect(described_class.use_primary?).to be true
+    end
+  end
+
+  describe '.install_reset_hook' do
+    let(:executor) { Class.new(ActiveSupport::Executor) }
+
+    it 'releases the context at the start of every executor run' do
+      described_class.install_reset_hook(executor)
+      described_class.stick_to_primary
+
+      stuck_inside = nil
+      executor.wrap { stuck_inside = described_class.use_primary? }
+
+      expect(stuck_inside).to be false
+    end
+
+    it 'stops stickiness leaking from a previous run into the next' do
+      described_class.install_reset_hook(executor)
+
+      executor.wrap { described_class.stick_to_primary }
+
+      leaked = nil
+      executor.wrap { leaked = described_class.use_primary? }
+      expect(leaked).to be false
     end
   end
 end


### PR DESCRIPTION
## What

Release Janus' per-request primary stickiness automatically between units of work, and store the context the same way ActiveRecord does.

## Why

Janus pins a unit of work to the primary after a write so later reads stay consistent. That state lived in a raw thread variable and was only ever cleared by calling `Janus::Context.release_all` by hand. On pooled, long-lived threads (Puma, Sidekiq) a thread that performed **one** write therefore kept sending **every** subsequent read to the primary for the rest of its life — quietly starving the replica.

## How

- Add a `Railtie` that releases the context at the start of each unit of work wrapped by the Rails executor (web requests, ActiveJob and Sidekiq-on-Rails jobs), so stickiness can no longer leak between them.
- Store the context in `ActiveSupport::IsolatedExecutionState` so it follows the app's configured isolation level (thread/fiber), like ActiveRecord.
- Drop the unused `expiry` / `potential_write` members and the misleading doc comment.

The reset logic is exposed as `Janus::Context.install_reset_hook(executor)`; non-Rails apps can keep calling `release_all` themselves.

## Tests

Covers context reset/isolation and the executor hook against a real `ActiveSupport::Executor`, including that stickiness from one run does not leak into the next.