### PR TITLE
Correct docs and modernise CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ jobs:
       matrix:
         ruby:
           - '3.2'
+          - '3.3'
+          - '3.4'
+          - '4.0'
     name: Ruby ${{ matrix.ruby }}
     services:
       mysql:
@@ -31,7 +34,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
@@ -51,7 +54,7 @@ jobs:
   RuboCop:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.2'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,9 @@ inherit_from:
 require:
   - rubocop-rails
 
+AllCops:
+  SuggestExtensions: false
+
 Style/Documentation:
   Enabled: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    janus-ar (7.2.0)
+    janus-ar (8.0.0)
       activerecord (>= 8.0, < 9.0)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@
 [![CI](https://github.com/OLIOEX/janus-ar/actions/workflows/ci.yml/badge.svg)](https://github.com/OLIOEX/janus-ar/actions/workflows/ci.yml)
 [![Gem Version](https://badge.fury.io/rb/janus-ar.svg)](https://badge.fury.io/rb/janus-ar)
 
-Janus ActiveRecord is generic primary/replica proxy for ActiveRecord 7.1+ and MySQL (via `mysql2` and `trilogy`). It handles the switching of connections between primary and replica database servers. It comes with an ActiveRecord database adapter implementation.
+Janus ActiveRecord is a generic primary/replica proxy for ActiveRecord 8 and MySQL (via `mysql2` and `trilogy`). It handles the switching of connections between primary and replica database servers. It comes with an ActiveRecord database adapter implementation.
 
 Janus is heavily inspired by [Makara](https://github.com/instacart/makara) from TaskRabbit and then Instacart. Unfortunately this project is unmaintained and broke for us with Rails 7.1. This is an attempt to start afresh on the project. It is definitely not as fully featured as Makara at this stage.
 
 Learn more about its origins: [https://tech.olioex.com/ruby/2024/04/16/introducing-janus.html](https://tech.olioex.com/ruby/2024/04/16/introducing-janus.html).
 
-Notes: GEM is currently tested with MySQL 8, Ruby 3.2, ActiveRecord 7.1+
+Notes: the gem requires ActiveRecord `>= 8.0, < 9.0` and Ruby `>= 3.2`, and is tested against MySQL 8.
 
 ## Installation
 
@@ -83,12 +83,13 @@ Otherwise you will get an error like the following (see https://github.com/trilo
 
 ### Forcing connections
 
-A context is local to the curent thread of execution. This will allow you to stick to the primary safely in a single thread
-in systems such as sidekiq, for instance.
+A context is local to the current unit of work (thread or fiber, following ActiveRecord's configured isolation level). This allows you to stick to the primary safely within a single request or job, in systems such as Sidekiq for instance.
 
 #### Releasing stuck connections (clearing context)
 
-If you need to clear the current context, releasing any stuck connections, all you have to do is:
+In a Rails application the context is released automatically at the start of every unit of work wrapped by the Rails executor — web requests, ActiveJob and Sidekiq-on-Rails jobs — so stickiness from a write never leaks into the next request on a reused thread. You do not need to do anything for this.
+
+Outside of Rails (or to clear the context manually), call:
 
 ```ruby
 Janus::Context.release_all


### PR DESCRIPTION
## What

Documentation, version and CI housekeeping.

## Why / How

- **README** claimed "ActiveRecord 7.1+", but the gemspec requires `>= 8.0, < 9.0`, so the gem will not install on 7.1. State the real supported range, and document that the context is now released automatically per request/job in Rails.
- Refresh the stale `janus-ar` version pinned in `Gemfile.lock` (`7.2.0` → `8.0.0`).
- Run CI across Ruby 3.2, 3.3 and 3.4, and upgrade the deprecated `actions/checkout@v2` → `v4`.
- Silence the RuboCop `SuggestExtensions` tip.

> Note: the README change documents the automatic per-request reset introduced in the "release primary stickiness automatically" PR, so this is best merged after it.