### PR TITLE
Feat/replica failover

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,24 @@ development:
       password: ithappenstobedifferent
       host: replica-host.local
 ```
+
+#### Replica failover (optional)
+
+By default a read that cannot reach the replica raises. Set `replica_failover: true` under `janus` to instead log a warning and retry the read on the primary when the replica connection fails:
+
+```yml
+  janus:
+    replica_failover: true
+    primary:
+      <<: *default
+      host: primary-host.local
+    replica:
+      <<: *default
+      host: replica-host.local
+```
+
+Only connection errors trigger the fallback; query errors still surface. This is a per-query retry with no circuit breaker, so for a sustained replica outage you should still rely on your endpoint-level failover (e.g. DNS).
+
 Note: For `trilogy` please use adapter "janus_trilogy". You'll probably need to add the following to your configuration to have it connect:
 
 ```yml

--- a/lib/janus-ar/active_record/connection_adapters/janus_mysql2_adapter.rb
+++ b/lib/janus-ar/active_record/connection_adapters/janus_mysql2_adapter.rb
@@ -3,6 +3,7 @@
 require 'active_record/connection_adapters/abstract_adapter'
 require 'active_record/connection_adapters/mysql2_adapter'
 require_relative '../../../janus-ar'
+require_relative '../../adapter_extensions'
 
 module ActiveRecord
   module ConnectionHandling
@@ -10,139 +11,21 @@ module ActiveRecord
       ActiveRecord::ConnectionAdapters::JanusMysql2Adapter.new(config)
     end
   end
-end
 
-module ActiveRecord
   class Base
     def self.janus_mysql2_adapter_class
       ActiveRecord::ConnectionAdapters::JanusMysql2Adapter
     end
   end
-end
 
-module ActiveRecord
   module ConnectionAdapters
     class JanusMysql2Adapter < ActiveRecord::ConnectionAdapters::Mysql2Adapter
-      FOUND_ROWS = 'FOUND_ROWS'
-
-      attr_reader :config
-
-      class << self
-        def dbconsole(config, options = {})
-          connection_config = Janus::DbConsoleConfig.new(config)
-
-          super(connection_config, options)
-        end
-      end
-
-      def initialize(*args)
-        args[0][:janus]['replica']['database'] = args[0][:database]
-        args[0][:janus]['primary']['database'] = args[0][:database]
-
-        @replica_config = args[0][:janus]['replica']
-        args[0] = args[0][:janus]['primary']
-
-        super(*args)
-        @connection_parameters ||= args[0]
-        update_config
-      end
-
-      def with_connection(_args = {})
-        self
-      end
-
-      def raw_execute(sql, name = nil, binds = [], prepare: false, async: false, allow_retry: false,
-        materialize_transactions: true, batch: false)
-        case where_to_send?(sql)
-        when :all
-          send_to_replica(sql, connection: :all, method: :raw_execute)
-          super
-        when :replica
-          send_to_replica(sql, connection: :replica, method: :raw_execute)
-        else
-          Janus::Context.stick_to_primary if write_query?(sql)
-          Janus::Context.used_connection(:primary)
-          super
-        end
-      end
-
-      def execute(sql)
-        case where_to_send?(sql)
-        when :all
-          send_to_replica(sql, connection: :all, method: :execute)
-          super(sql)
-        when :replica
-          send_to_replica(sql, connection: :replica, method: :execute)
-        else
-          Janus::Context.stick_to_primary if write_query?(sql)
-          Janus::Context.used_connection(:primary)
-          super(sql)
-        end
-      end
-
-      def execute_and_free(sql, name = nil, async: false)
-        case where_to_send?(sql)
-        when :all
-          send_to_replica(sql, connection: :all, method: :execute)
-          super(sql, name, async:)
-        when :replica
-          send_to_replica(sql, connection: :replica, method: :execute)
-        else
-          Janus::Context.stick_to_primary if write_query?(sql)
-          Janus::Context.used_connection(:primary)
-          super(sql, name, async:)
-        end
-      end
-
-      def connect!(...)
-        replica_connection.connect!(...)
-        super
-      end
-
-      def reconnect!(...)
-        replica_connection.reconnect!(...)
-        super
-      end
-
-      def disconnect!(...)
-        replica_connection.disconnect!(...)
-        super
-      end
-
-      def clear_cache!(...)
-        replica_connection.clear_cache!(...)
-        super
-      end
-
-      def replica_connection
-        @replica_connection ||= ActiveRecord::ConnectionAdapters::Mysql2Adapter.new(@replica_config)
-      end
+      include Janus::AdapterExtensions
 
       private
 
-      def where_to_send?(sql)
-        Janus::QueryDirector.new(sql, open_transactions).where_to_send?
-      end
-
-      def send_to_replica(sql, connection: nil, method: :exec_query)
-        Janus::Context.used_connection(connection) if connection
-        if method == :execute
-          replica_connection.execute(sql)
-        elsif method == :raw_execute
-          replica_connection.execute(sql)
-        else
-          replica_connection.exec_query(sql)
-        end
-      end
-
-      def update_config
-        @config[:flags] ||= 0
-
-        if @config[:flags].is_a? Array
-          @config[:flags].push FOUND_ROWS
-        else
-          @config[:flags] |= ::Janus::Client::FOUND_ROWS
-        end
+      def replica_adapter_class
+        ActiveRecord::ConnectionAdapters::Mysql2Adapter
       end
     end
   end

--- a/lib/janus-ar/active_record/connection_adapters/janus_trilogy_adapter.rb
+++ b/lib/janus-ar/active_record/connection_adapters/janus_trilogy_adapter.rb
@@ -3,6 +3,7 @@
 require 'active_record/connection_adapters/abstract_adapter'
 require 'active_record/connection_adapters/trilogy_adapter'
 require_relative '../../../janus-ar'
+require_relative '../../adapter_extensions'
 
 module ActiveRecord
   module ConnectionHandling
@@ -10,139 +11,21 @@ module ActiveRecord
       ActiveRecord::ConnectionAdapters::JanusTrilogyAdapter.new(config)
     end
   end
-end
 
-module ActiveRecord
   class Base
     def self.janus_trilogy_adapter_class
       ActiveRecord::ConnectionAdapters::JanusTrilogyAdapter
     end
   end
-end
 
-module ActiveRecord
   module ConnectionAdapters
     class JanusTrilogyAdapter < ActiveRecord::ConnectionAdapters::TrilogyAdapter
-      FOUND_ROWS = 'FOUND_ROWS'
-
-      attr_reader :config
-
-      class << self
-        def dbconsole(config, options = {})
-          connection_config = Janus::DbConsoleConfig.new(config)
-
-          super(connection_config, options)
-        end
-      end
-
-      def initialize(*args)
-        args[0][:janus]['replica']['database'] = args[0][:database]
-        args[0][:janus]['primary']['database'] = args[0][:database]
-
-        @replica_config = args[0][:janus]['replica'].symbolize_keys
-        args[0] = args[0][:janus]['primary'].symbolize_keys
-
-        super(*args)
-        @connection_parameters ||= args[0]
-        update_config
-      end
-
-      def raw_execute(sql, name = nil, binds = [], prepare: false, async: false, allow_retry: false,
-        materialize_transactions: true, batch: false)
-        case where_to_send?(sql)
-        when :all
-          send_to_replica(sql, connection: :all, method: :execute)
-          super
-        when :replica
-          send_to_replica(sql, connection: :replica, method: :execute)
-        else
-          Janus::Context.stick_to_primary if write_query?(sql)
-          Janus::Context.used_connection(:primary)
-          super
-        end
-      end
-
-      def execute(sql)
-        case where_to_send?(sql)
-        when :all
-          send_to_replica(sql, connection: :all, method: :execute)
-          super(sql)
-        when :replica
-          send_to_replica(sql, connection: :replica, method: :execute)
-        else
-          Janus::Context.stick_to_primary if write_query?(sql)
-          Janus::Context.used_connection(:primary)
-          super(sql)
-        end
-      end
-
-      def execute_and_free(sql, name = nil, async: false)
-        case where_to_send?(sql)
-        when :all
-          send_to_replica(sql, connection: :all, method: :execute)
-          super(sql, name, async:)
-        when :replica
-          send_to_replica(sql, connection: :replica, method: :execute)
-        else
-          Janus::Context.stick_to_primary if write_query?(sql)
-          Janus::Context.used_connection(:primary)
-          super(sql, name, async:)
-        end
-      end
-
-      def with_connection(_args = {})
-        self
-      end
-
-      def connect!(...)
-        replica_connection.connect!(...)
-        super
-      end
-
-      def reconnect!(...)
-        replica_connection.reconnect!(...)
-        super
-      end
-
-      def disconnect!(...)
-        replica_connection.disconnect!(...)
-        super
-      end
-
-      def clear_cache!(...)
-        replica_connection.clear_cache!(...)
-        super
-      end
-
-      def replica_connection
-        @replica_connection ||= ActiveRecord::ConnectionAdapters::TrilogyAdapter.new(@replica_config)
-      end
+      include Janus::AdapterExtensions
 
       private
 
-      def where_to_send?(sql)
-        Janus::QueryDirector.new(sql, open_transactions).where_to_send?
-      end
-
-      def send_to_replica(sql, connection: nil, method: :exec_query)
-        Janus::Context.used_connection(connection) if connection
-        if method == :execute
-          replica_connection.execute(sql)
-        elsif method == :raw_execute
-          replica_connection.execute(sql)
-        else
-          replica_connection.exec_query(sql)
-        end
-      end
-
-      def update_config
-        @config[:flags] ||= 0
-
-        if @config[:flags].is_a? Array
-          @config[:flags].push FOUND_ROWS
-        else
-          @config[:flags] |= ::Janus::Client::FOUND_ROWS
-        end
+      def replica_adapter_class
+        ActiveRecord::ConnectionAdapters::TrilogyAdapter
       end
     end
   end

--- a/lib/janus-ar/adapter_extensions.rb
+++ b/lib/janus-ar/adapter_extensions.rb
@@ -10,6 +10,20 @@ module Janus
   #
   # Including adapters only need to implement #replica_adapter_class.
   module AdapterExtensions
+    # Connection-level errors that trigger a fall back to the primary when
+    # `replica_failover` is enabled. Query errors (bad SQL etc.) are not
+    # included on purpose: they would fail against the primary too, so failing
+    # over would only hide the real problem.
+    REPLICA_FAILOVER_ERRORS = [
+      ActiveRecord::ConnectionNotEstablished,
+      ActiveRecord::ConnectionFailed,
+    ].freeze
+
+    # Internal marker returned by #send_to_replica when a read could not reach
+    # the replica and should be retried on the primary.
+    FAILOVER = Object.new
+    private_constant :FAILOVER
+
     def self.included(base)
       base.extend(ClassMethods)
     end
@@ -27,6 +41,7 @@ module Janus
       config[:janus]['replica']['database'] = config[:database]
       config[:janus]['primary']['database'] = config[:database]
 
+      @replica_failover = config[:janus].fetch('replica_failover', false)
       @replica_config = config[:janus]['replica'].symbolize_keys
       args[0] = config[:janus]['primary'].symbolize_keys
 
@@ -37,50 +52,33 @@ module Janus
     # The argument lists below intentionally use anonymous splats and a bare
     # `super`: ActiveRecord's `raw_execute`/`execute` signatures differ between
     # versions, so we forward whatever we are given unchanged rather than
-    # restating (and pinning ourselves to) the current signature.
+    # restating (and pinning ourselves to) the current signature. The block
+    # given to #route runs the statement on the primary.
     def raw_execute(sql, *, **)
-      case where_to_send?(sql)
-      when :all
-        send_to_replica(sql, :all)
-        super
-      when :replica
-        send_to_replica(sql, :replica)
-      else
-        mark_primary(sql)
-        super
-      end
+      route(sql) { super }
     end
 
     def execute(sql, *, **)
-      case where_to_send?(sql)
-      when :all
-        send_to_replica(sql, :all)
-        super
-      when :replica
-        send_to_replica(sql, :replica)
-      else
-        mark_primary(sql)
-        super
-      end
+      route(sql) { super }
     end
 
     def connect!(...)
-      replica_connection.connect!(...)
+      guard_replica { replica_connection.connect!(...) }
       super
     end
 
     def reconnect!(...)
-      replica_connection.reconnect!(...)
+      guard_replica { replica_connection.reconnect!(...) }
       super
     end
 
     def disconnect!(...)
-      replica_connection.disconnect!(...)
+      guard_replica { replica_connection.disconnect!(...) }
       super
     end
 
     def clear_cache!(...)
-      replica_connection.clear_cache!(...)
+      guard_replica { replica_connection.clear_cache!(...) }
       super
     end
 
@@ -89,6 +87,22 @@ module Janus
     end
 
     private
+
+    def route(sql)
+      case where_to_send?(sql)
+      when :all
+        send_to_replica(sql, :all)
+      when :replica
+        result = send_to_replica(sql, :replica)
+        return result unless result.equal?(FAILOVER)
+
+        mark_primary(sql)
+      else
+        mark_primary(sql)
+      end
+
+      yield
+    end
 
     def mark_primary(sql)
       Janus::Context.stick_to_primary if write_query?(sql)
@@ -100,8 +114,23 @@ module Janus
     end
 
     def send_to_replica(sql, connection)
-      Janus::Context.used_connection(connection)
-      replica_connection.execute(sql)
+      guard_replica(FAILOVER) do
+        Janus::Context.used_connection(connection)
+        replica_connection.execute(sql)
+      end
+    end
+
+    # Runs a replica operation. When `replica_failover` is enabled, a replica
+    # connection error is logged and `failover_result` is returned instead of
+    # raising, so the caller can fall back to the primary. Otherwise the error
+    # propagates unchanged.
+    def guard_replica(failover_result = nil)
+      yield
+    rescue *REPLICA_FAILOVER_ERRORS => e
+      raise unless @replica_failover
+
+      Janus::Logging::Logger.log("replica unavailable, falling back to primary (#{e.class}: #{e.message})", :warn)
+      failover_result
     end
   end
 end

--- a/lib/janus-ar/adapter_extensions.rb
+++ b/lib/janus-ar/adapter_extensions.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+module Janus
+  # Behaviour shared by the Janus MySQL2 and Trilogy adapters.
+  #
+  # Each Janus adapter subclasses the matching ActiveRecord adapter and owns the
+  # *primary* connection (reached via `super`). This module routes every
+  # statement to the primary, a lazily created replica connection, or both, and
+  # keeps Janus::Context up to date.
+  #
+  # Including adapters only need to implement #replica_adapter_class.
+  module AdapterExtensions
+    def self.included(base)
+      base.extend(ClassMethods)
+    end
+
+    module ClassMethods
+      def dbconsole(config, options = {})
+        super(Janus::DbConsoleConfig.new(config), options)
+      end
+    end
+
+    attr_reader :config
+
+    def initialize(*args)
+      config = args[0]
+      config[:janus]['replica']['database'] = config[:database]
+      config[:janus]['primary']['database'] = config[:database]
+
+      @replica_config = config[:janus]['replica'].symbolize_keys
+      args[0] = config[:janus]['primary'].symbolize_keys
+
+      super
+      @connection_parameters ||= args[0]
+    end
+
+    # The argument lists below intentionally use anonymous splats and a bare
+    # `super`: ActiveRecord's `raw_execute`/`execute` signatures differ between
+    # versions, so we forward whatever we are given unchanged rather than
+    # restating (and pinning ourselves to) the current signature.
+    def raw_execute(sql, *, **)
+      case where_to_send?(sql)
+      when :all
+        send_to_replica(sql, :all)
+        super
+      when :replica
+        send_to_replica(sql, :replica)
+      else
+        mark_primary(sql)
+        super
+      end
+    end
+
+    def execute(sql, *, **)
+      case where_to_send?(sql)
+      when :all
+        send_to_replica(sql, :all)
+        super
+      when :replica
+        send_to_replica(sql, :replica)
+      else
+        mark_primary(sql)
+        super
+      end
+    end
+
+    def connect!(...)
+      replica_connection.connect!(...)
+      super
+    end
+
+    def reconnect!(...)
+      replica_connection.reconnect!(...)
+      super
+    end
+
+    def disconnect!(...)
+      replica_connection.disconnect!(...)
+      super
+    end
+
+    def clear_cache!(...)
+      replica_connection.clear_cache!(...)
+      super
+    end
+
+    def replica_connection
+      @replica_connection ||= replica_adapter_class.new(@replica_config)
+    end
+
+    private
+
+    def mark_primary(sql)
+      Janus::Context.stick_to_primary if write_query?(sql)
+      Janus::Context.used_connection(:primary)
+    end
+
+    def where_to_send?(sql)
+      Janus::QueryDirector.new(sql, open_transactions).where_to_send?
+    end
+
+    def send_to_replica(sql, connection)
+      Janus::Context.used_connection(connection)
+      replica_connection.execute(sql)
+    end
+  end
+end

--- a/spec/lib/janus-ar/active_record/connection_adapters/janus_mysql_adapter_spec.rb
+++ b/spec/lib/janus-ar/active_record/connection_adapters/janus_mysql_adapter_spec.rb
@@ -75,4 +75,24 @@ RSpec.describe ActiveRecord::ConnectionAdapters::JanusMysql2Adapter do
 
     it_behaves_like 'a mysql like server'
   end
+
+  describe 'Replica failover' do
+    let(:dead_replica_config) { replica_config.merge('port' => 13_306) }
+    let(:failover_config) do
+      {
+        database:,
+        adapter: 'janus_mysql2',
+        janus: { 'replica_failover' => true, 'primary' => primary_config, 'replica' => dead_replica_config },
+      }
+    end
+    let(:no_failover_config) do
+      {
+        database:,
+        adapter: 'janus_mysql2',
+        janus: { 'primary' => primary_config, 'replica' => dead_replica_config },
+      }
+    end
+
+    it_behaves_like 'a failover capable server'
+  end
 end

--- a/spec/lib/janus-ar/active_record/connection_adapters/janus_mysql_adapter_spec.rb
+++ b/spec/lib/janus-ar/active_record/connection_adapters/janus_mysql_adapter_spec.rb
@@ -92,6 +92,13 @@ RSpec.describe ActiveRecord::ConnectionAdapters::JanusMysql2Adapter do
         janus: { 'primary' => primary_config, 'replica' => dead_replica_config },
       }
     end
+    let(:healthy_failover_config) do
+      {
+        database:,
+        adapter: 'janus_mysql2',
+        janus: { 'replica_failover' => true, 'primary' => primary_config, 'replica' => replica_config },
+      }
+    end
 
     it_behaves_like 'a failover capable server'
   end

--- a/spec/lib/janus-ar/active_record/connection_adapters/janus_mysql_adapter_spec.rb
+++ b/spec/lib/janus-ar/active_record/connection_adapters/janus_mysql_adapter_spec.rb
@@ -3,8 +3,6 @@
 RSpec.describe ActiveRecord::ConnectionAdapters::JanusMysql2Adapter do
   subject { described_class.new(config) }
 
-  it { expect(described_class::FOUND_ROWS).to eq 'FOUND_ROWS' }
-
   let(:database) { 'test' }
   let(:primary_config) do
     {
@@ -73,10 +71,8 @@ RSpec.describe ActiveRecord::ConnectionAdapters::JanusMysql2Adapter do
   end
 
   describe 'Integration tests' do
-    describe 'Integration tests' do
-      let(:table_name) { 'table_name_mysql2' }
+    let(:table_name) { 'table_name_mysql2' }
 
-      it_behaves_like 'a mysql like server'
-    end
+    it_behaves_like 'a mysql like server'
   end
 end

--- a/spec/lib/janus-ar/active_record/connection_adapters/janus_trilogy_adapter_spec.rb
+++ b/spec/lib/janus-ar/active_record/connection_adapters/janus_trilogy_adapter_spec.rb
@@ -74,4 +74,24 @@ RSpec.describe ActiveRecord::ConnectionAdapters::JanusTrilogyAdapter do
 
     it_behaves_like 'a mysql like server'
   end
+
+  describe 'Replica failover' do
+    let(:dead_replica_config) { replica_config.merge('port' => 13_306) }
+    let(:failover_config) do
+      {
+        database:,
+        adapter: 'janus_trilogy',
+        janus: { 'replica_failover' => true, 'primary' => primary_config, 'replica' => dead_replica_config },
+      }
+    end
+    let(:no_failover_config) do
+      {
+        database:,
+        adapter: 'janus_trilogy',
+        janus: { 'primary' => primary_config, 'replica' => dead_replica_config },
+      }
+    end
+
+    it_behaves_like 'a failover capable server'
+  end
 end

--- a/spec/lib/janus-ar/active_record/connection_adapters/janus_trilogy_adapter_spec.rb
+++ b/spec/lib/janus-ar/active_record/connection_adapters/janus_trilogy_adapter_spec.rb
@@ -3,8 +3,6 @@
 RSpec.describe ActiveRecord::ConnectionAdapters::JanusTrilogyAdapter do
   subject { described_class.new(config) }
 
-  it { expect(described_class::FOUND_ROWS).to eq 'FOUND_ROWS' }
-
   let(:database) { 'test' }
   let(:primary_config) do
     {
@@ -14,7 +12,6 @@ RSpec.describe ActiveRecord::ConnectionAdapters::JanusTrilogyAdapter do
       'ssl' => true,
       'ssl_mode' => 'REQUIRED',
       'tls_min_version' => Trilogy::TLS_VERSION_12,
-      'found_rows' => true,
     }
   end
   let(:replica_config) do
@@ -26,7 +23,6 @@ RSpec.describe ActiveRecord::ConnectionAdapters::JanusTrilogyAdapter do
       'ssl' => true,
       'ssl_mode' => 'REQUIRED',
       'tls_min_version' => Trilogy::TLS_VERSION_12,
-      'found_rows' => true,
     }
   end
   let(:config) do
@@ -41,17 +37,19 @@ RSpec.describe ActiveRecord::ConnectionAdapters::JanusTrilogyAdapter do
   end
 
   describe 'Configuration' do
+    # Trilogy enables FOUND_ROWS via the `found_rows` option (not mysql2-style
+    # flags), and ActiveRecord's TrilogyAdapter forces it on. We assert it is
+    # present even though the supplied config omits it.
     it 'creates primary connection as expected' do
       config = primary_config.dup.freeze
-      expect(subject.config).to eq config.merge('database' => database,
-                                                'flags' => ::Janus::Client::FOUND_ROWS).symbolize_keys
+      expect(subject.config).to eq config.merge('database' => database, 'found_rows' => true).symbolize_keys
     end
 
     it 'creates replica connection as expected' do
       config = replica_config.dup.freeze
       expect(
         subject.replica_connection.instance_variable_get(:@config)
-      ).to eq config.merge('database' => database).symbolize_keys
+      ).to eq config.merge('database' => database, 'found_rows' => true).symbolize_keys
     end
 
     context 'Rails sets empty database for server connection' do
@@ -59,17 +57,14 @@ RSpec.describe ActiveRecord::ConnectionAdapters::JanusTrilogyAdapter do
 
       it 'creates primary connection as expected' do
         config = primary_config.dup.freeze
-        expect(subject.config).to eq config.merge(
-          'database' => nil,
-          'flags' => ::Janus::Client::FOUND_ROWS
-        ).symbolize_keys
+        expect(subject.config).to eq config.merge('database' => nil, 'found_rows' => true).symbolize_keys
       end
 
       it 'creates replica connection as expected' do
         config = replica_config.dup.freeze
         expect(
           subject.replica_connection.instance_variable_get(:@config)
-        ).to eq config.merge('database' => nil).symbolize_keys
+        ).to eq config.merge('database' => nil, 'found_rows' => true).symbolize_keys
       end
     end
   end

--- a/spec/lib/janus-ar/active_record/connection_adapters/janus_trilogy_adapter_spec.rb
+++ b/spec/lib/janus-ar/active_record/connection_adapters/janus_trilogy_adapter_spec.rb
@@ -91,6 +91,13 @@ RSpec.describe ActiveRecord::ConnectionAdapters::JanusTrilogyAdapter do
         janus: { 'primary' => primary_config, 'replica' => dead_replica_config },
       }
     end
+    let(:healthy_failover_config) do
+      {
+        database:,
+        adapter: 'janus_trilogy',
+        janus: { 'replica_failover' => true, 'primary' => primary_config, 'replica' => replica_config },
+      }
+    end
 
     it_behaves_like 'a failover capable server'
   end

--- a/spec/lib/janus-ar/db_console_config_spec.rb
+++ b/spec/lib/janus-ar/db_console_config_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'janus-ar/db_console_config'
+
+RSpec.describe Janus::DbConsoleConfig do
+  subject(:console_config) { described_class.new(db_config) }
+
+  let(:db_config) do
+    instance_double(
+      ActiveRecord::DatabaseConfigurations::HashConfig,
+      configuration_hash: {
+        database: 'my_database',
+        janus: {
+          'primary' => { 'host' => 'primary.local', 'username' => 'primary' },
+          'replica' => { 'host' => 'replica.local', 'username' => 'replica' },
+        },
+      }
+    )
+  end
+
+  it 'exposes the replica configuration with symbol keys so dbconsole connects to a replica' do
+    expect(console_config.configuration_hash).to eq(host: 'replica.local', username: 'replica')
+  end
+
+  it 'exposes the database name from the top-level config' do
+    expect(console_config.database).to eq('my_database')
+  end
+end

--- a/spec/lib/janus-ar/logging/subscriber_spec.rb
+++ b/spec/lib/janus-ar/logging/subscriber_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'janus-ar/context'
+require 'janus-ar/logging/subscriber'
+
+RSpec.describe Janus::Logging::Subscriber do
+  # A minimal stand-in for ActiveRecord::LogSubscriber: it records the event it
+  # is given so we can assert on the (possibly rewritten) payload name.
+  let(:base_class) do
+    Class.new do
+      attr_reader :received_event
+
+      def sql(event)
+        @received_event = event
+      end
+    end
+  end
+  let(:subscriber) { base_class.new.extend(described_class) }
+  let(:event) { instance_double(ActiveSupport::Notifications::Event, payload: { name: 'User Load' }) }
+
+  after(:each) { Janus::Context.release_all }
+
+  it 'tags the log name with the last used connection' do
+    Janus::Context.used_connection(:replica)
+
+    subscriber.sql(event)
+
+    expect(event.payload[:name]).to eq('[replica] User Load')
+    expect(subscriber.received_event).to eq(event)
+  end
+
+  it 'reflects the primary connection' do
+    Janus::Context.used_connection(:primary)
+
+    subscriber.sql(event)
+
+    expect(event.payload[:name]).to eq('[primary] User Load')
+  end
+
+  it 'leaves the name unchanged when no connection has been used yet' do
+    Janus::Context.release_all
+
+    subscriber.sql(event)
+
+    expect(event.payload[:name]).to eq('User Load')
+  end
+
+  Janus::Logging::Subscriber::IGNORE_PAYLOAD_NAMES.each do |ignored|
+    it "does not tag #{ignored} statements" do
+      Janus::Context.used_connection(:replica)
+      ignored_event = instance_double(ActiveSupport::Notifications::Event, payload: { name: ignored })
+
+      subscriber.sql(ignored_event)
+
+      expect(ignored_event.payload[:name]).to eq(ignored)
+    end
+  end
+end

--- a/spec/shared_examples/a_failover_capable_server.rb
+++ b/spec/shared_examples/a_failover_capable_server.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# Expects the including context to provide `failover_config` and
+# `no_failover_config`, both pointing at a healthy primary and an unreachable
+# replica.
+RSpec.shared_examples 'a failover capable server' do
+  before(:each) { Janus::Context.release_all }
+
+  context 'when replica_failover is enabled' do
+    it 'serves an otherwise replica-bound read from the primary' do
+      ActiveRecord::Base.establish_connection(failover_config)
+      # Warm up the primary so its connection-setup runs before we assert.
+      ActiveRecord::Base.connection.execute('SELECT 1')
+      Janus::Context.release_all
+
+      result = ActiveRecord::Base.connection.exec_query('SELECT 1 AS one')
+
+      expect(result.rows).to eq [[1]]
+      expect(Janus::Context.last_used_connection).to eq :primary
+    end
+  end
+
+  context 'when replica_failover is disabled' do
+    it 'lets the replica connection error surface' do
+      ActiveRecord::Base.establish_connection(no_failover_config)
+      Janus::Context.release_all
+
+      expect { ActiveRecord::Base.connection.exec_query('SELECT 1 AS one') }.to raise_error do |error|
+        expect(Janus::AdapterExtensions::REPLICA_FAILOVER_ERRORS.any? { |klass| error.is_a?(klass) }).to be true
+      end
+    end
+  end
+end

--- a/spec/shared_examples/a_failover_capable_server.rb
+++ b/spec/shared_examples/a_failover_capable_server.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
-# Expects the including context to provide `failover_config` and
-# `no_failover_config`, both pointing at a healthy primary and an unreachable
-# replica.
+# Expects the including context to provide:
+#   * `failover_config`         - healthy primary, unreachable replica, failover ON
+#   * `no_failover_config`      - healthy primary, unreachable replica, failover OFF
+#   * `healthy_failover_config` - healthy primary and replica, failover ON
 RSpec.shared_examples 'a failover capable server' do
   before(:each) { Janus::Context.release_all }
 
@@ -17,6 +18,24 @@ RSpec.shared_examples 'a failover capable server' do
 
       expect(result.rows).to eq [[1]]
       expect(Janus::Context.last_used_connection).to eq :primary
+    end
+
+    it 'still applies a broadcast SET on the primary when the replica is down' do
+      ActiveRecord::Base.establish_connection(failover_config)
+      Janus::Context.release_all
+
+      expect do
+        ActiveRecord::Base.connection.execute("SET SESSION time_zone = '+00:00'")
+      end.not_to raise_error
+    end
+
+    it 'does not swallow a genuine query error from a healthy replica' do
+      ActiveRecord::Base.establish_connection(healthy_failover_config)
+      Janus::Context.release_all
+
+      expect do
+        ActiveRecord::Base.connection.exec_query('SELECT * FROM a_table_that_does_not_exist')
+      end.to raise_error(ActiveRecord::StatementInvalid)
     end
   end
 

--- a/spec/shared_examples/a_mysql_like_server.rb
+++ b/spec/shared_examples/a_mysql_like_server.rb
@@ -106,4 +106,50 @@ RSpec.shared_examples 'a mysql like server' do
       expect($query_logger.queries.first).to include '[replica]'
     end
   end
+
+  describe 'Transactions' do
+    before(:each) do
+      create_test_table
+      Janus::Context.release_all
+      $query_logger.flush_all
+    end
+
+    it 'routes reads inside a transaction to the primary' do
+      ActiveRecord::Base.transaction do
+        ActiveRecord::Base.connection.execute("SELECT * FROM `#{table_name}`;")
+      end
+
+      selects = $query_logger.queries.select { |q| q.downcase.include?("select * from `#{table_name}`") }
+      expect(selects).not_to be_empty
+      expect(selects).to all(include('[primary]'))
+    end
+
+    it 'keeps later reads on the primary until the context is released' do
+      ActiveRecord::Base.transaction do
+        ActiveRecord::Base.connection.execute("INSERT INTO `#{table_name}` SET `id` = 1;")
+      end
+      $query_logger.flush_all
+
+      ActiveRecord::Base.connection.execute("SELECT * FROM `#{table_name}`;")
+      expect($query_logger.queries.last).to include '[primary]'
+
+      Janus::Context.release_all
+      ActiveRecord::Base.connection.execute("SELECT * FROM `#{table_name}`;")
+      expect($query_logger.queries.last).to include '[replica]'
+    end
+  end
+
+  describe 'SET statements' do
+    before(:each) { Janus::Context.release_all }
+
+    it 'sends a session SET down the broadcast (:all) path without error' do
+      expect do
+        ActiveRecord::Base.connection.execute("SET SESSION time_zone = '+00:00'")
+      end.not_to raise_error
+
+      # `:all` means the statement ran against the replica connection too, not
+      # just the primary - a write would have been marked `:primary`.
+      expect(Janus::Context.last_used_connection).to eq :all
+    end
+  end
 end

--- a/spec/shared_examples/a_mysql_like_server.rb
+++ b/spec/shared_examples/a_mysql_like_server.rb
@@ -82,4 +82,28 @@ RSpec.shared_examples 'a mysql like server' do
       expect(Janus::Context.last_used_connection).to eq :replica
     end
   end
+
+  describe 'ActiveRecord compatibility' do
+    before(:each) do
+      create_test_table
+      Janus::Context.release_all
+    end
+
+    it 'accepts the optional name argument on #execute' do
+      expect do
+        ActiveRecord::Base.connection.execute("SELECT * FROM `#{table_name}`;", 'CustomName')
+      end.not_to raise_error
+    end
+
+    it 'returns a usable result through the exec_query read path' do
+      ActiveRecord::Base.connection.execute("INSERT INTO `#{table_name}` SET `id` = 7;")
+      Janus::Context.release_all
+      $query_logger.flush_all
+
+      result = ActiveRecord::Base.connection.exec_query("SELECT `id` FROM `#{table_name}`")
+
+      expect(result.rows).to eq [[7]]
+      expect($query_logger.queries.first).to include '[replica]'
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,7 @@ ActiveRecord::ConnectionAdapters.register("janus_trilogy", "ActiveRecord::Connec
 ActiveRecord::ConnectionAdapters.register("janus_mysql2", "ActiveRecord::ConnectionAdapters::JanusMysql2Adapter")
 
 require './spec/shared_examples/a_mysql_like_server.rb'
+require './spec/shared_examples/a_failover_capable_server.rb'
 
 class QueryLogger
   def initialize


### PR DESCRIPTION
## What

Add an opt-in fallback that retries a read on the primary when the replica connection fails.

> Stacked on `fix/adapter-robustness` (the shared adapter module lives there). Base is that branch; GitHub will retarget to `main` once it merges.

## Why

Today a read that cannot reach the replica raises and takes the request down — even though the primary could have served it.

## How

Set `replica_failover: true` under the `janus` config:

```yml
janus:
  replica_failover: true
  primary: { ... }
  replica: { ... }
```

- Only connection-level errors (`ConnectionNotEstablished` / `ConnectionFailed`) trigger the fallback; query errors still surface, so genuine bugs aren't hidden.
- The same guard wraps the replica side of `connect!`/`reconnect!`/`disconnect!`/`clear_cache!`, so a down replica no longer blocks the primary while failover is enabled.
- Per-query retry, **no circuit breaker** — sustained outages should still be handled at the endpoint level (e.g. DNS). Documented as such.
- The dispatch is consolidated into a single `route` helper shared by `raw_execute`/`execute`.

## Tests

Against MySQL 8, for both adapters: a read succeeds via the primary when the replica is unreachable and failover is on, and surfaces the connection error when it is off.