### PR TITLE
Route all locking reads to the primary

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    janus-ar (8.0.0)
+    janus-ar (8.0.1)
       activerecord (>= 8.0, < 9.0)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ There are some edge cases:
 * `SET` operations will be sent to all connections
 * Execution of specific methods such as `connect!`, `disconnect!`, `reconnect!`, and `clear_cache!` are invoked on all underlying connections
 * Calls inside a transaction will always be sent to the primary (otherwise changes from within the transaction could not be read back on most transaction isolation levels)
-* Locking reads (e.g. `SELECT ... FOR UPDATE`) will always be sent to the primary
+* Locking reads (e.g. `SELECT ... FOR UPDATE`, `FOR UPDATE SKIP LOCKED`, `FOR SHARE`, `LOCK IN SHARE MODE`, `GET_LOCK(...)`) will always be sent to the primary
 
 # Notes
 

--- a/lib/janus-ar/query_director.rb
+++ b/lib/janus-ar/query_director.rb
@@ -5,10 +5,24 @@ module Janus
     REPLICA = :replica
     PRIMARY = :primary
 
+    # Reading any of these takes or inspects a lock, so it has to happen on the
+    # primary to mean anything.
+    LOCK_FUNCTIONS = %w(
+      nextval currval lastval get_lock release_lock is_free_lock is_used_lock
+      pg_advisory_lock pg_advisory_unlock
+    ).freeze
+
+    # These are matched anywhere in the statement (hence `/m`, and no `\Z`
+    # anchor): a locking clause is not always the final token on a single line.
+    # `FOR UPDATE SKIP LOCKED`, `FOR UPDATE NOWAIT`, `FOR UPDATE OF t`, MySQL
+    # 8's `FOR SHARE`, a trailing semicolon and multi-line formatting all have
+    # to reach the primary, or the lock is taken on a replica nobody else
+    # contends on and the application only believes it has mutual exclusion.
     SQL_PRIMARY_MATCHERS = [
-      /\A\s*select.+for update\Z/i, /select.+lock in share mode\Z/i,
-      /\A\s*select.+(nextval|currval|lastval|get_lock|release_lock|pg_advisory_lock|pg_advisory_unlock)\(/i,
-      /\A\s*show/i
+      /\A\s*select\b.*\bfor\s+(update|share)\b/im,
+      /\A\s*select\b.*\block\s+in\s+share\s+mode\b/im,
+      /\A\s*select\b.*\b(#{LOCK_FUNCTIONS.join('|')})\s*\(/im,
+      /\A\s*show\b/i,
     ].freeze
     SQL_REPLICA_MATCHERS = [/\A\s*(select|with.+\)\s*select)\s/i].freeze
     SQL_ALL_MATCHERS = [/\A\s*set\s/i].freeze

--- a/lib/janus-ar/query_director.rb
+++ b/lib/janus-ar/query_director.rb
@@ -5,19 +5,11 @@ module Janus
     REPLICA = :replica
     PRIMARY = :primary
 
-    # Reading any of these takes or inspects a lock, so it has to happen on the
-    # primary to mean anything.
     LOCK_FUNCTIONS = %w(
       nextval currval lastval get_lock release_lock is_free_lock is_used_lock
       pg_advisory_lock pg_advisory_unlock
     ).freeze
 
-    # These are matched anywhere in the statement (hence `/m`, and no `\Z`
-    # anchor): a locking clause is not always the final token on a single line.
-    # `FOR UPDATE SKIP LOCKED`, `FOR UPDATE NOWAIT`, `FOR UPDATE OF t`, MySQL
-    # 8's `FOR SHARE`, a trailing semicolon and multi-line formatting all have
-    # to reach the primary, or the lock is taken on a replica nobody else
-    # contends on and the application only believes it has mutual exclusion.
     SQL_PRIMARY_MATCHERS = [
       /\A\s*select\b.*\bfor\s+(update|share)\b/im,
       /\A\s*select\b.*\block\s+in\s+share\s+mode\b/im,

--- a/spec/lib/janus-ar/query_director_spec.rb
+++ b/spec/lib/janus-ar/query_director_spec.rb
@@ -118,8 +118,6 @@ RSpec.describe Janus::QueryDirector do
         end
       end
 
-      # `for update` / `for share` only force the primary when they are the
-      # locking clause, not when they are part of a longer identifier.
       {
         'a read whose column is named for_update' => 'SELECT for_update FROM users',
         'a read whose column is named lock_in_share_mode' => 'SELECT lock_in_share_mode FROM users',

--- a/spec/lib/janus-ar/query_director_spec.rb
+++ b/spec/lib/janus-ar/query_director_spec.rb
@@ -6,10 +6,17 @@ RSpec.describe Janus::QueryDirector do
     it {
       expect(described_class::SQL_PRIMARY_MATCHERS).to eq(
         [
-          /\A\s*select.+for update\Z/i, /select.+lock in share mode\Z/i,
-          /\A\s*select.+(nextval|currval|lastval|get_lock|release_lock|pg_advisory_lock|pg_advisory_unlock)\(/i,
-          /\A\s*show/i
+          /\A\s*select\b.*\bfor\s+(update|share)\b/im,
+          /\A\s*select\b.*\block\s+in\s+share\s+mode\b/im,
+          /\A\s*select\b.*\b(#{described_class::LOCK_FUNCTIONS.join('|')})\s*\(/im,
+          /\A\s*show\b/i,
         ]
+      )
+    }
+    it {
+      expect(described_class::LOCK_FUNCTIONS).to eq(
+        %w(nextval currval lastval get_lock release_lock is_free_lock is_used_lock pg_advisory_lock
+           pg_advisory_unlock)
       )
     }
     it { expect(described_class::SQL_REPLICA_MATCHERS).to eq([/\A\s*(select|with.+\)\s*select)\s/i]) }
@@ -87,16 +94,39 @@ RSpec.describe Janus::QueryDirector do
     end
 
     context 'with locking reads' do
-      it 'routes SELECT ... FOR UPDATE to the primary' do
-        expect(described_class.new('SELECT * FROM users FOR UPDATE', 0).where_to_send?).to eq(:primary)
+      {
+        'SELECT ... FOR UPDATE' => 'SELECT * FROM users FOR UPDATE',
+        'SELECT ... LOCK IN SHARE MODE' => 'SELECT * FROM users LOCK IN SHARE MODE',
+        'SELECT ... FOR UPDATE SKIP LOCKED' => 'SELECT * FROM jobs LIMIT 1 FOR UPDATE SKIP LOCKED',
+        'SELECT ... FOR UPDATE NOWAIT' => 'SELECT * FROM jobs FOR UPDATE NOWAIT',
+        'SELECT ... FOR UPDATE OF' => 'SELECT * FROM jobs AS j FOR UPDATE OF j',
+        'SELECT ... FOR SHARE' => 'SELECT * FROM jobs FOR SHARE',
+        'SELECT ... FOR SHARE NOWAIT' => 'SELECT * FROM jobs FOR SHARE NOWAIT',
+        'SELECT ... FOR UPDATE with a trailing semicolon' => 'SELECT * FROM users FOR UPDATE;',
+        'SELECT ... FOR UPDATE with trailing whitespace' => "SELECT * FROM users FOR UPDATE\n",
+        'a multi-line SELECT ... FOR UPDATE' => "SELECT *\nFROM accounts\nWHERE id = 1\nFOR UPDATE",
+        'a multi-line SELECT ... LOCK IN SHARE MODE' => "SELECT *\nFROM accounts\nLOCK IN SHARE MODE",
+        'SELECT ... FOR UPDATE split across lines' => "SELECT * FROM users\nFOR\nUPDATE",
+        'advisory lock reads' => "SELECT get_lock('x', 0)",
+        'a multi-line advisory lock read' => "SELECT\n  GET_LOCK(\"x\", 10)",
+        'IS_FREE_LOCK reads' => "SELECT IS_FREE_LOCK('x')",
+        'IS_USED_LOCK reads' => "SELECT IS_USED_LOCK('x')",
+        'advisory lock reads with space before the paren' => "SELECT get_lock ('x', 0)",
+      }.each do |label, query|
+        it "routes #{label} to the primary" do
+          expect(described_class.new(query, 0).where_to_send?).to eq(:primary)
+        end
       end
 
-      it 'routes SELECT ... LOCK IN SHARE MODE to the primary' do
-        expect(described_class.new('SELECT * FROM users LOCK IN SHARE MODE', 0).where_to_send?).to eq(:primary)
-      end
-
-      it 'routes advisory lock reads to the primary' do
-        expect(described_class.new("SELECT get_lock('x', 0)", 0).where_to_send?).to eq(:primary)
+      # `for update` / `for share` only force the primary when they are the
+      # locking clause, not when they are part of a longer identifier.
+      {
+        'a read whose column is named for_update' => 'SELECT for_update FROM users',
+        'a read whose column is named lock_in_share_mode' => 'SELECT lock_in_share_mode FROM users',
+      }.each do |label, query|
+        it "routes #{label} to the replica" do
+          expect(described_class.new(query, 0).where_to_send?).to eq(:replica)
+        end
       end
     end
 

--- a/spec/shared_examples/a_mysql_like_server.rb
+++ b/spec/shared_examples/a_mysql_like_server.rb
@@ -107,6 +107,24 @@ RSpec.shared_examples 'a mysql like server' do
     end
   end
 
+  describe 'Locking reads' do
+    before(:each) do
+      create_test_table
+      Janus::Context.release_all
+      $query_logger.flush_all
+    end
+
+    it 'sends a FOR UPDATE SKIP LOCKED claim to the primary' do
+      ActiveRecord::Base.connection.execute("SELECT * FROM `#{table_name}` LIMIT 1 FOR UPDATE SKIP LOCKED")
+      expect($query_logger.queries.last).to include '[primary]'
+    end
+
+    it 'sends a multi-line locking read to the primary' do
+      ActiveRecord::Base.connection.execute("SELECT *\nFROM `#{table_name}`\nWHERE id = 1\nFOR UPDATE")
+      expect($query_logger.queries.last).to include '[primary]'
+    end
+  end
+
   describe 'Transactions' do
     before(:each) do
       create_test_table


### PR DESCRIPTION
Fixes finding 1 (Critical) of #176.

## Problem

`SQL_PRIMARY_MATCHERS` anchored the locking-read patterns with `\Z` and omitted `/m`, so a locking read only reached the primary when `FOR UPDATE` / `LOCK IN SHARE MODE` was the last token on a single line. Everything else was routed to the replica:

| Statement | Before | After |
|---|---|---|
| `SELECT ... LIMIT 1 FOR UPDATE SKIP LOCKED` | replica | primary |
| `SELECT ... FOR UPDATE NOWAIT` | replica | primary |
| `SELECT ... FOR UPDATE OF a` | replica | primary |
| `SELECT ... FOR SHARE` (MySQL 8) | replica | primary |
| `SELECT ... FOR UPDATE;` | replica | primary |
| multi-line `SELECT ... FOR UPDATE` | replica | primary |
| multi-line `SELECT GET_LOCK(...)` | replica | primary |
| `SELECT IS_FREE_LOCK(...)` / `IS_USED_LOCK(...)` | replica | primary |

The lock was therefore taken on a replica nobody else contends on, so the application believed it had mutual exclusion when it did not — or the statement raised, on a `super_read_only` replica. `FOR UPDATE SKIP LOCKED` is exactly what Solid Queue and GoodJob emit to claim a job, so every worker could claim the same job.

## Change

- Drop the `\Z` anchors and add `/m` so the locking clause matches anywhere in the statement.
- Match MySQL 8's `FOR SHARE` alongside `FOR UPDATE`.
- Add `IS_FREE_LOCK` / `IS_USED_LOCK` to the lock functions, and allow whitespace before the opening paren.
- Extract the lock function list into a `LOCK_FUNCTIONS` constant.
- Anchor the `LOCK IN SHARE MODE` matcher on `SELECT` like the others.
- Word boundaries keep identifiers such as a `for_update` column on the replica.
- README: list the locking forms that are pinned to the primary.

Findings 2-7 of #176 are not touched here.

## Verification

Unit specs cover each shape above (13 of the new examples failed before the fix), plus two integration examples per adapter (`FOR UPDATE SKIP LOCKED` and a multi-line locking read) asserting the query is logged against `[primary]` — both failed against the old regexes for MySQL2 and Trilogy.

Full suite against a local MySQL 8 with the CI `primary`/`replica` users: `119 examples, 0 failures`. RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)