### PR TITLE
Forward `discard!` to the replica connection

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    janus-ar (8.0.0)
+    janus-ar (8.0.1)
       activerecord (>= 8.0, < 9.0)
 
 GEM

--- a/lib/janus-ar/adapter_extensions.rb
+++ b/lib/janus-ar/adapter_extensions.rb
@@ -74,11 +74,6 @@ module Janus
       super
     end
 
-    # ActiveRecord's ForkTracker discards every adapter in a forked child so
-    # that the child never closes a socket the parent is still using. The
-    # replica connection needs the same treatment, otherwise the child's
-    # replica client sends COM_QUIT down the parent's socket when it is
-    # garbage collected.
     def discard!(...)
       replica_connection.discard!(...)
       super

--- a/lib/janus-ar/adapter_extensions.rb
+++ b/lib/janus-ar/adapter_extensions.rb
@@ -74,6 +74,16 @@ module Janus
       super
     end
 
+    # ActiveRecord's ForkTracker discards every adapter in a forked child so
+    # that the child never closes a socket the parent is still using. The
+    # replica connection needs the same treatment, otherwise the child's
+    # replica client sends COM_QUIT down the parent's socket when it is
+    # garbage collected.
+    def discard!(...)
+      replica_connection.discard!(...)
+      super
+    end
+
     def disconnect!(...)
       replica_connection.disconnect!(...)
       super

--- a/spec/lib/janus-ar/active_record/connection_adapters/janus_mysql_adapter_spec.rb
+++ b/spec/lib/janus-ar/active_record/connection_adapters/janus_mysql_adapter_spec.rb
@@ -70,6 +70,12 @@ RSpec.describe ActiveRecord::ConnectionAdapters::JanusMysql2Adapter do
     end
   end
 
+  describe 'Connection lifecycle' do
+    let(:replica_adapter_class) { ActiveRecord::ConnectionAdapters::Mysql2Adapter }
+
+    it_behaves_like 'an adapter forwarding lifecycle calls'
+  end
+
   describe 'Integration tests' do
     let(:table_name) { 'table_name_mysql2' }
 

--- a/spec/lib/janus-ar/active_record/connection_adapters/janus_trilogy_adapter_spec.rb
+++ b/spec/lib/janus-ar/active_record/connection_adapters/janus_trilogy_adapter_spec.rb
@@ -69,6 +69,12 @@ RSpec.describe ActiveRecord::ConnectionAdapters::JanusTrilogyAdapter do
     end
   end
 
+  describe 'Connection lifecycle' do
+    let(:replica_adapter_class) { ActiveRecord::ConnectionAdapters::TrilogyAdapter }
+
+    it_behaves_like 'an adapter forwarding lifecycle calls'
+  end
+
   describe 'Integration tests' do
     let(:table_name) { 'table_name_trilogy' }
 

--- a/spec/shared_examples/an_adapter_forwarding_lifecycle_calls.rb
+++ b/spec/shared_examples/an_adapter_forwarding_lifecycle_calls.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# ActiveRecord's ForkTracker calls `discard!` on every adapter in a forked
+# child so the child never closes a socket the parent is still using. Janus
+# owns a second (replica) connection, so it has to pass that on.
+RSpec.shared_examples 'an adapter forwarding lifecycle calls' do
+  let(:replica_connection) { instance_double(replica_adapter_class) }
+
+  before do
+    allow(subject).to receive(:replica_connection).and_return(replica_connection)
+  end
+
+  it 'forwards discard! to the replica connection' do
+    allow(replica_connection).to receive(:discard!)
+
+    subject.discard!
+
+    expect(replica_connection).to have_received(:discard!)
+  end
+end

--- a/spec/shared_examples/an_adapter_forwarding_lifecycle_calls.rb
+++ b/spec/shared_examples/an_adapter_forwarding_lifecycle_calls.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-# ActiveRecord's ForkTracker calls `discard!` on every adapter in a forked
-# child so the child never closes a socket the parent is still using. Janus
-# owns a second (replica) connection, so it has to pass that on.
 RSpec.shared_examples 'an adapter forwarding lifecycle calls' do
   let(:replica_connection) { instance_double(replica_adapter_class) }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,7 @@ ActiveRecord::ConnectionAdapters.register("janus_trilogy", "ActiveRecord::Connec
 ActiveRecord::ConnectionAdapters.register("janus_mysql2", "ActiveRecord::ConnectionAdapters::JanusMysql2Adapter")
 
 require './spec/shared_examples/a_mysql_like_server.rb'
+require './spec/shared_examples/an_adapter_forwarding_lifecycle_calls.rb'
 
 class QueryLogger
   def initialize


### PR DESCRIPTION
Fixes finding 2 of #176.

ActiveRecord registers `ActiveSupport::ForkTracker.after_fork { PoolConfig.discard_pools! }`, which calls `discard!` on every adapter in a forked child so the child never closes a socket it shares with the parent. Janus forwarded `connect!`, `reconnect!`, `disconnect!` and `clear_cache!` to the replica but not `discard!`, so in a forked child (Puma cluster, Sidekiq swarm, Spring, parallel test runners) the replica adapter kept a live `Mysql2::Client` / `Trilogy` object. Garbage collecting it in the child sends `COM_QUIT` down the socket the parent is still using.

```ruby
def discard!(...)
  replica_connection.discard!(...)
  super
end
```

## Tests

New shared example `an adapter forwarding lifecycle calls`, included from both the mysql2 and trilogy adapter specs. Verified red before the fix (`received: 0 times`) and green after. RuboCop clean.

## Note on the audit text

The issue says "`throw_away!` calls `discard!` internally so it is covered by the same override". That is not true in AR 8.1.3.1 — `throw_away!` is `pool.remove self; disconnect!`. `disconnect!` is already forwarded to the replica, so that path is fine, but it does not go through `discard!`. No extra override needed.

The remaining findings in #176 are not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)