### PR TITLE
Fix automated RubyGems publishing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,4 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-      
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
@@ -59,7 +59,7 @@ jobs:
   RuboCop:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.2'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - v*
+
 jobs:
   push:
     runs-on: ubuntu-latest
@@ -14,12 +15,42 @@ jobs:
 
     steps:
       # Set up
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          bundler-cache: true
-          ruby-version: ruby
+          ruby-version: '3.4'
+
+      # `rubygems/release-gem` runs `bundle exec rake release`, which refuses to
+      # publish from a dirty working tree. Install to the system gem dir (rather
+      # than `bundler-cache: true`, which writes `vendor/bundle` and rewrites
+      # `.bundle/config`) so the checkout stays pristine.
+      - name: Install dependencies
+        run: bundle install --jobs 4
+
+      # Guards: both of these fail with a cryptic
+      # "There are files that need to be committed first" inside `rake release`
+      # if we let them through.
+      - name: Check tag matches gem version
+        run: |
+          gem_version="$(ruby -Ilib -r janus-ar/version -e 'print Janus::VERSION.to_s')"
+          tag_version="${GITHUB_REF_NAME#v}"
+          if [ "$gem_version" != "$tag_version" ]; then
+            echo "::error::Tag ${GITHUB_REF_NAME} does not match lib/janus-ar/version.rb (${gem_version}). Use bin/release.sh to cut releases."
+            exit 1
+          fi
+
+      - name: Check working tree is clean
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "::error::Working tree is dirty after installing dependencies - Gemfile.lock is probably out of sync with the gemspec. Run 'bundle install' locally and commit the result."
+            git status --porcelain
+            git diff
+            exit 1
+          fi
 
       # Release
       - uses: rubygems/release-gem@v1

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 janus-ar-*.gem
 .rubocop-*
 gemfiles/*.gemfile.lock
+/pkg/
+/vendor/

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,11 @@
 PATH
   remote: .
   specs:
-    janus-ar (8.0.0)
+    janus-ar (8.0.1)
       activerecord (>= 8.0, < 9.0)
 
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     activemodel (8.1.3.1)
       activesupport (= 8.1.3.1)

--- a/README.md
+++ b/README.md
@@ -128,3 +128,24 @@ Janus does not support Rails' read/write split or sharding using `with_connectio
 # Acknowlegements
 
 Amazing project logo by @undevelopedbruce.
+
+## Releasing
+
+Releases are published to RubyGems automatically by
+[`.github/workflows/publish.yml`](.github/workflows/publish.yml) when a `v*` tag
+is pushed. Authentication uses RubyGems
+[trusted publishing](https://guides.rubygems.org/trusted-publishing/) via OIDC —
+there is no API key to rotate.
+
+To cut a release:
+
+```bash
+bin/release.sh 8.1.0
+git push origin HEAD --follow-tags
+```
+
+`bin/release.sh` bumps `lib/janus-ar/version.rb`, regenerates `Gemfile.lock`
+(which records the gem's own version) and creates the tag. The tag name and the
+version in `version.rb` must match, and the working tree must be clean at the
+tagged commit — the publish workflow checks both before attempting to push the
+gem.

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -1,4 +1,70 @@
 #!/bin/bash
-rm janus-ar-*.gem
-gem build janus-ar.gemspec
-gem push janus-ar-*.gem
+#
+# Cut a release. Bumps lib/janus-ar/version.rb, refreshes Gemfile.lock, commits
+# and tags. Pushing the tag triggers .github/workflows/publish.yml, which
+# publishes to RubyGems via trusted publishing.
+#
+# Usage: bin/release.sh 8.1.0
+#
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+version="${1:-}"
+if [ -z "$version" ]; then
+  echo "Usage: bin/release.sh <version>   e.g. bin/release.sh 8.1.0" >&2
+  exit 1
+fi
+
+if ! [[ "$version" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)(\.(.+))?$ ]]; then
+  echo "Version must look like MAJOR.MINOR.PATCH[.PRE], got '${version}'" >&2
+  exit 1
+fi
+major="${BASH_REMATCH[1]}"
+minor="${BASH_REMATCH[2]}"
+patch="${BASH_REMATCH[3]}"
+pre="${BASH_REMATCH[5]:-}"
+pre_literal="nil"
+[ -n "$pre" ] && pre_literal="'${pre}'"
+
+if [ -n "$(git status --porcelain)" ]; then
+  echo "Working tree is dirty; commit or clean it before releasing." >&2
+  exit 1
+fi
+
+if git rev-parse -q --verify "refs/tags/v${version}" >/dev/null; then
+  echo "Tag v${version} already exists." >&2
+  exit 1
+fi
+
+cat > lib/janus-ar/version.rb <<RUBY
+# frozen_string_literal: true
+
+module Janus
+  unless defined?(::Janus::VERSION)
+    module VERSION
+      MAJOR = ${major}
+      MINOR = ${minor}
+      PATCH = ${patch}
+      PRE = ${pre_literal}
+
+      def self.to_s
+        [MAJOR, MINOR, PATCH, PRE].compact.join('.')
+      end
+    end
+  end
+  ::Janus::VERSION
+end
+RUBY
+
+# Gemfile.lock records the gem's own version, so it has to be regenerated in
+# the same commit or the publish workflow will refuse to release.
+bundle install --quiet
+
+git add lib/janus-ar/version.rb Gemfile.lock
+git commit -m "Release v${version}"
+git tag -a "v${version}" -m "Version ${version}"
+
+echo
+echo "Committed and tagged v${version}. Push with:"
+echo "  git push origin HEAD --follow-tags"

--- a/janus-ar.gemspec
+++ b/janus-ar.gemspec
@@ -13,8 +13,10 @@ Gem::Specification.new do |gem|
     'source_code_uri' => 'https://github.com/olioex/janus-ar',
   }
 
-  gem.files         = `git ls-files`.split($OUTPUT_RECORD_SEPARATOR)
-  gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
+  ignored           = %r{^(bin|spec|assets|gemfiles|\.github)/|^\.}
+  gem.files         = `git ls-files`.split($OUTPUT_RECORD_SEPARATOR).grep_v(ignored)
+  # The gem ships no executables; bin/ holds repository maintenance scripts.
+  gem.executables   = []
   gem.name          = 'janus-ar'
   gem.require_paths = %w(lib)
   gem.version       = Janus::VERSION


### PR DESCRIPTION
## Why

The publish workflow has never successfully released a gem. Only one run has ever fired — tag `v8.0.1`, 2026-06-19 — and it died in `release:guard_clean`:

```
janus-ar 8.0.0 built to pkg/janus-ar-8.0.0.gem.
rake aborted!
There are files that need to be committed first.
Tasks: TOP => release => release:guard_clean
```

8.0.1 was then published by hand three minutes later.

Two independent things dirtied the checkout:

1. **`Gemfile.lock` records the gem's own version** in its `PATH` section. It said `janus-ar (8.0.0)` while `version.rb` said `8.0.1`, so `bundle install` in CI rewrote it. This would recur on *every* release, since the lock has to be bumped alongside `version.rb`.
2. **`bundler-cache: true`** writes `vendor/bundle` (not gitignored) and rewrites the tracked `.bundle/config`.

Separately, the `v8.0.1` tag points at a commit where `version.rb` still said `8.0.0` — so even a clean tree would have published the wrong version.

**Trusted publishing is already set up correctly.** `rubygems/configure-rubygems-credentials` completed and exported the OIDC token in that run; the job only failed afterwards. No credential work is needed, and the unused `RUBYGEMS_API_KEY` repo secret (created 2024) can be deleted.

## What changed

- **`.github/workflows/publish.yml`** — plain `bundle install` instead of `bundler-cache` so nothing is written into the working tree; `ruby-version: '3.4'` instead of `ruby` (was resolving to 4.0.5); `fetch-depth: 0` so `release:source_control_push` sees the tag as already created; two guard steps that fail with a readable message on tag/version mismatch or a dirty tree, rather than the cryptic `guard_clean` error.
- **`bin/release.sh`** — was `gem build && gem push`, i.e. the manual path that bypassed CI entirely. Now validates the version, rewrites `version.rb`, regenerates `Gemfile.lock`, commits and tags — keeping the two in lockstep so cause #1 can't come back.
- **`janus-ar.gemspec`** — the gem was shipping `bin/release.sh` as an installed **executable** onto users' `PATH` (`spec.executables == ["release.sh"]`). Now `[]`, and `spec.files` drops `bin/ spec/ assets/ gemfiles/ .github/` and dotfiles (28 files → 19).
- **`Gemfile`** — `http://rubygems.org` → `https`. **`Gemfile.lock`** resynced to 8.0.1.
- **`actions/checkout` v4 → v7** (v4 runs on deprecated Node 20 — visible as a warning in the failed run) and **dependabot now covers `github-actions`**, which was bundler-only and let checkout fall three majors behind.
- **`.gitignore`** — `/pkg/`, `/vendor/`. **`README.md`** — release process documented.

## Verification

- `rubocop --parallel` clean; all three YAML files parse.
- Both guard scripts exercised against matching and mismatching tags.
- `bundle exec rake build` produces `janus-ar-8.0.1.gem`; `bundle install` leaves the tree clean.
- `bin/release.sh` tested end-to-end in a scratch repo: rejects malformed versions, rejects existing tags, handles pre-release suffixes (`8.2.0.rc1`).
- `rspec` not run locally (needs MySQL with the replica/primary users) — CI covers it, and no library code is touched.

## Note / open question

Nothing gates publishing on tests: CI runs on `main` and PRs but **not on tag pushes**, so `publish.yml` will ship a gem regardless of whether the suite is green at that commit. In practice tags are cut from an already-tested `main`. Happy to add an `rspec` step (plus the MySQL service block) to the publish job, or require the CI run on the tagged SHA to have passed, if you'd rather it were enforced.

## Next release

```bash
bin/release.sh 8.0.2
git push origin HEAD --follow-tags
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)